### PR TITLE
Adding environment variable for Adminer

### DIFF
--- a/adminer/Chart.yaml
+++ b/adminer/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7
+version: 0.1.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/adminer/templates/deployment.yaml
+++ b/adminer/templates/deployment.yaml
@@ -33,6 +33,13 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.env }}
+          env:
+            {{- range $key, $value := . }}
+            - name: {{ $key | quote }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/adminer/values.yaml
+++ b/adminer/values.yaml
@@ -84,3 +84,15 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# The Adminer container utilizes a few environment variables to update behaviour:
+# ADMINER_PLUGINS - In a space-delimited list, specify any official Adminer plugin to enable.
+#                   All plugins can be viewed here: https://github.com/vrana/adminer/tree/master/plugins
+# ADMINER_DESIGN - Specify the name of any official theme to utilize this design.
+#                  All designs can be viewed here: https://github.com/vrana/adminer/tree/master/designs
+# ADMINER_DEFAULT_SERVER - This specifies the default server to connect to.
+env: {}
+# Example:
+# env:
+#   ADMINER_PLUGINS: "designs tables-filter tinymce"
+#   ADMINER_DESIGN: "pepa-linha-dark"


### PR DESCRIPTION
This PR adds the ability to add environment variables for Adminer to utilize.


Currently, variables in `values.yml` would be inputted like this:
```
env:
   ADMINER_PLUGINS: "designs tables-filter tinymce"
   ADMINER_DESIGN: "pepa-linha-dark"
```

however, if using `toYaml` is preferred instead of the `range` loop, I can make that update. Expected `values.yml` would then be like this:
```
env:
  - name: ADMINER_PLUGINS
    value: "designs tables-filter tinymce"
  - name: ADMINER_DESIGN
    value: "pepa-linha-dark"
```